### PR TITLE
Accept null values for MetaData.getObjectClassDefinitions()

### DIFF
--- a/src/main/java/net/distilledcode/tools/osgi/Comparison.java
+++ b/src/main/java/net/distilledcode/tools/osgi/Comparison.java
@@ -93,6 +93,10 @@ public class Comparison {
     @SuppressWarnings("unchecked")
     private static Map<String, OCD> toOCDMap(MetaData metaData) {
         Map<String, OCD> ocds = metaData.getObjectClassDefinitions();
+        // if OCDs without AD children in metatype < 1.3 then ocds = null
+        if (ocds == null) {
+            return Collections.emptyMap();
+        }
         List<Designate> designates = metaData.getDesignates();
         Stream<Designate> stream = designates == null ? Stream.empty() : designates.stream();
         Function<Designate, String> designateStringFunction = d -> d.getObject().getOcdRef();

--- a/src/main/java/net/distilledcode/tools/osgi/MetadataDiff.java
+++ b/src/main/java/net/distilledcode/tools/osgi/MetadataDiff.java
@@ -38,8 +38,12 @@ public class MetadataDiff {
         PrintingVisitor visitor = new PrintingVisitor(out);
 
         for (final String className : allClasses) {
-            Comparison comparison = Comparison.create(className, leftBundleMetadata, rightBundleMetadata);
-            comparison.visit(visitor);
+            try {
+                Comparison comparison = Comparison.create(className, leftBundleMetadata, rightBundleMetadata);
+                comparison.visit(visitor);
+            } catch (Exception e) {
+                throw new IOException("Could not diff metadata for class '" + className + "'", e);
+            }
         }
 
         if (!visitor.hasPrintedSomething()) {


### PR DESCRIPTION
Wrap all exceptions to include the current class name

This closes #1